### PR TITLE
Remove compiler warnings

### DIFF
--- a/dollarskip.c
+++ b/dollarskip.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
 char command[4096];
-*buff = 0;
 int main(int argc, char **argv)
 {
 for (int i=1; i<argc; i++){


### PR DESCRIPTION
```bash
[itai@pinebookpro DollarSkip]$ make
gcc dollarskip.c -o temp
dollarskip.c:4:1: warning: data definition has no type or storage class
    4 | *buff = 0;
      | ^
dollarskip.c:4:2: warning: type defaults to ‘int’ in declaration of ‘buff’ [-Wimplicit-int]
    4 | *buff = 0;
      |  ^~~~
[itai@pinebookpro DollarSkip]$
```
it works, but it's nicer if there are no .
as you see in this part:
```bash
dollarskip.c:4:2: warning: type defaults to ‘int’ in declaration of ‘buff’ [-Wimplicit-int]
    4 | *buff = 0;
      |  ^~~~
```
it sets it as a `int`, so setting it to a `int` will still work (I checked). also I didn't see anywhere that pointer is being used, so I removed it and it still works.