### PR TITLE
Better makefile

### DIFF
--- a/dollarskip.c
+++ b/dollarskip.c
@@ -7,7 +7,7 @@
 
 char **parse(char *input) {
     //will hold the command
-    char **command=malloc(sizeof(char *)*8);
+    char **command=malloc(sizeof(char *)*8096);
     //the separator for strtok
     char *separator=" ";
     //will hold the parsed output from strtok
@@ -29,7 +29,7 @@ char **parse(char *input) {
 
 int main(int argc, char **argv)
 {
-	char *input=malloc(sizeof(argv)*2+1);
+	char input[8096];
 	char **command;
 	pid_t child_pid;
 	int exit=0, stat_loc;
@@ -53,8 +53,6 @@ int main(int argc, char **argv)
 		} else {
 			waitpid(child_pid, &stat_loc, WUNTRACED); //parent process waits until child has finished
 		}
-
-		free(input);
 		free(command);
 	}
 	//if exit is 1 (set if the command failed to run), return from the child process

--- a/dollarskip.c
+++ b/dollarskip.c
@@ -1,25 +1,65 @@
+#include <stdio.h> //perror
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h> //execvp
+#include <errno.h> //errno (error handling)
+#include <sys/wait.h> //waitpid
+
+char **parse(char *input) {
+    //will hold the command
+    char **command=malloc(sizeof(char *)*8);
+    //the separator for strtok
+    char *separator=" ";
+    //will hold the parsed output from strtok
+    char *parsed;
+    int index=0;
+
+    //strtok returns the first word in 'input' before the space
+    parsed=strtok(input, separator);
+    //while that word isn't NULL
+    while(parsed!=NULL) {
+        command[index]=parsed; //copy it to command[index]
+        index++; //increment index
+        parsed=strtok(NULL, separator); //get the next word from strtok
+    }
+
+    command[index]=NULL;
+    return command;
+}
+
 int main(int argc, char **argv)
 {
-	char command[8096] = {0};
+	char *input=malloc(sizeof(argv)*2+1);
+	char **command;
+	pid_t child_pid;
+	int exit=0, stat_loc;
+
 	if(argc>1) {
-		char shell[128] = {0}, *env=getenv("SHELL"); //get the env var 'SHELL'
-		if(strcmp(env, "")) { //if env != ""
-			strcpy(shell, env); //copy env to shell
-			strcat(shell, " -c \'"); //add " -c '"
-			strcat(command, shell); //add it to command
-			for (int i=1; i<argc; i++){
-				strcat(strcat(command,argv[i])," ");
-			} //add all the command (cmd args) to command
-			command[strlen(command) - 1] = '\0';
-			strcat(command, "\'");// add "'"
-		} else {
-			for (int i=1; i<argc; i++){
-				strcat(strcat(command,argv[i])," ");
-			}
-			command[strlen(command) - 1] = '\0';
+		strcpy(input, argv[1]);
+		for(int i = 2; i<argc; i++) {
+			strcat(input, " ");
+			strcat(input, argv[i]);
 		}
-		system(command);// run the command
+		command = parse(input);
+		//fork the shell process
+		child_pid = fork();
+		if(child_pid == 0) { //when the child process gets here, its 'child_pid' is 0 because it has no child
+			if(execvp(command[0], command) == -1) { //execvp will only return if it fails
+				perror("DollarSkip"); //error handling
+				exit=1; //set exit to 1 for 'if' statement at the end
+			}
+		} else if(child_pid < 0) {
+			perror("DollarSkip");
+		} else {
+			waitpid(child_pid, &stat_loc, WUNTRACED); //parent process waits until child has finished
+		}
+
+		free(input);
+		free(command);
 	}
+	//if exit is 1 (set if the command failed to run), return from the child process
+	if(exit==1) {
+		return 1;
+	}
+	return 0;
 }

--- a/makefile
+++ b/makefile
@@ -1,12 +1,18 @@
-.SILENT: test
+CC?=gcc
 
-make: dollarskip.c
-	gcc dollarskip.c -o temp
-install: make
+all: temp
+
+temp: dollarskip.c
+	$(CC) dollarskip.c -o temp
+
+install: temp
 	cp temp /usr/bin/\$
-uninstall: install
-	rm /usr/bin/\$
-clean: make
-	rm temp
+
+uninstall:
+	-rm /usr/bin/\$
+
+clean:
+	-rm temp
+
 build-debug: dollarskip.c
-	gcc dollarskip.c -o temp -g -Wall
+	$(CC) dollarskip.c -o temp -g -Wall

--- a/makefile
+++ b/makefile
@@ -1,12 +1,12 @@
 .SILENT: test
 
-make :
+make: dollarskip.c
 	gcc dollarskip.c -o temp
-install :
+install: make
 	cp temp /usr/bin/\$
-uninstall :
+uninstall: install
 	rm /usr/bin/\$
-clean :
+clean: make
 	rm temp
-build-debug :
-	gcc dollarskip.c -o temp -Wall
+build-debug: dollarskip.c
+	gcc dollarskip.c -o temp -g -Wall


### PR DESCRIPTION
the targets now depend on the things they should:
`make` and `make-debug` - dollarskip.c
`install` and `clean` - `make`
`uninstall` - `install`

that means that now for example if you run `sudo make install` without running `make` first, make will automatically run the `make` target first.