### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,9 @@ jobs:
               
       - name: make
         run: make
-        
-      - name: test
-        run: |
-          mkdir -p ~/.local/bin
-          mv temp ~/.local/bin/\$
-          export PATH="$HOME/.local/bin":$PATH
-          $ echo 123
+      
+      - name: upload binary
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: DollarSkip_build
+          path: ./temp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,9 @@ jobs:
         run: make
         
       - name: test 
-        run: ./temp echo 1
+        run: |
+          ls
+          ./temp echo 1
       
       - name: ignore
         run: exit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
         
       - name: test
         run: |
+          mkdir -p ~/.local/bin
           mv temp ~/.local/bin/\$
           export PATH="$HOME/.local/bin":$PATH
           $ echo 123

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build Test
+name: Build
 
 # Controls when the action will run. 
 on:
@@ -23,11 +23,7 @@ jobs:
               
       - name: make
         run: make
-        
-      - name: test 
-        run: |
-          ls
-          ./temp echo 1
-      
-      - name: ignore
-        run: exit
+      - name: upload
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          path: ./temp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
               
       - name: make
         run: make
-      - name: upload
-        uses: actions/upload-artifact@v2.2.4
-        with:
-          path: ./temp
+      - name: test
+        run: |
+          chmod +x temp
+          ./temp $ echo 123

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,9 @@ jobs:
               
       - name: make
         run: make
+        
       - name: test
         run: |
-          chmod +x temp
-          ./temp $ echo 123
+          mv temp ~/.local/bin/\$
+          export PATH="$HOME/.local/bin":$PATH
+          $ echo 123


### PR DESCRIPTION
the gh actions runner is failing to run the binary, it exits with a segmentation fault for some reason.
In my fork, I made the action upload the executable, I put it in `/usr/bin` and it worked perfectly fine even with box64:
```
ubuntu@pi-builder:~/Downloads/artifact $ ls
temp
ubuntu@pi-builder:~/Downloads/artifact $ file temp
temp: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=6c2d20add7e6550f86605bc08fe92689f4b3c867, for GNU/Linux 3.2.0, not stripped
ubuntu@pi-builder:~/Downloads/artifact $ sudo mv temp /usr/bin/\$
ubuntu@pi-builder:~/Downloads/artifact $ $ echo test 123
Box64 with Dynarec v0.1.3 2976bf5 built on Jul 12 2021 13:53:42
Using default BOX64_LD_LIBRARY_PATH: ./:lib/:lib64/:x86_64/:bin64/:libs64/
Using default BOX64_PATH: ./:bin/
Counted 28 Env var
Looking for /usr/bin/$
argv[1]="echo"
argv[2]="test"
argv[3]="123"
Using native(wrapped) libc.so.6
Using native(wrapped) ld-linux-x86-64.so.2
Using native(wrapped) libpthread.so.0
Using native(wrapped) librt.so.1
test 123
ubuntu@pi-builder:~/Downloads/artifact $ 
```
but when running directly, it fails:
```
ubuntu@pi-builder:~/Downloads/artifact $ ls
temp
ubuntu@pi-builder:~/Downloads/artifact $ ./temp $ echo 123
Box64 with Dynarec v0.1.3 2976bf5 built on Jul 12 2021 13:53:42
Using default BOX64_LD_LIBRARY_PATH: ./:lib/:lib64/:x86_64/:bin64/:libs64/
Using default BOX64_PATH: ./:bin/
Counted 28 Env var
Looking for ./temp
argv[1]="$"
argv[2]="echo"
argv[3]="123"
Using native(wrapped) libc.so.6
Using native(wrapped) ld-linux-x86-64.so.2
Using native(wrapped) libpthread.so.0
Using native(wrapped) librt.so.1
/bin/bash: $: command not found
ubuntu@pi-builder:~/Downloads/artifact $ 
```
doing it natively does work:
```
pi@TwisterPi4:~/Documents/git/DollarSkip $ make
gcc dollarskip.c -o temp
pi@TwisterPi4:~/Documents/git/DollarSkip $ ./temp $ echo 123
123
pi@TwisterPi4:~/Documents/git/DollarSkip $ 
```
I tried making the action run it by putting the executable in `~/.local/bin/$` and adding that to $PATH, but it still didn't work.

### The changes I made to the workflow
- rename `main.yml` -> `build.yml`
- remove the test part
- make it upload the executable so we can test it later if we want