### PR TITLE
makefile: adopted `PREFIX`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ temp
 
 src/
 pkg/
-3.0.tar.gz
+3.*.tar.gz
 dollarskip*any.pkg.tar.zst

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname="dollarskip"
-pkgver="3.0"
+pkgver="3.1"
 pkgrel="1"
-source=(https://github.com/CleanMachine1/DollarSkip/archive/3.0.tar.gz)
+source=(https://github.com/CleanMachine1/DollarSkip/archive/3.1.tar.gz)
 pkgdesc="Skip the dollar!"
 arch=('any')
 url="https://github.com/CleanMachine1/DollarSkip"
@@ -15,6 +15,6 @@ build() {
 
 package() {
     cd DollarSkip-${pkgver} &&
-    install -m 755 -D temp "${pkgdir}/usr/bin/\$" 
+    install -m 755 -D temp "${pkgdir}/usr/local/bin/\$" 
 }
 sha256sums=('8826bd814c543566130152e6e2da02b0d43363ca51f5e806e208760918a2531e')

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ If you get a different output, please explain your situation and any error messa
 
 ```shell
 cd ~/DollarSkip # Or where you put the Git directory
-sudo make uninstall # Remove the binary in /usr/bin
+sudo make uninstall # Remove the binary in /usr/local/bin/
 cd .. 
 rm -rf ./DollarSkip
 
 # If the DollarSkip directory doesn't exist, simply run the following command:
 
-sudo rm /usr/bin/\$
+sudo rm /usr/local/bin/\$ # or /usr/bin/\$ (depending on when you installed).
 ```
 
 ## How this works

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ __To download and compile DollarSkip you need **Git** (to download the files) an
 <details>
 <summary>To install DollarSkip without Git or Make</summary>
 
-If you don't want to use Git and Make, you can download the zip from [here](https://github.com/CleanMachine1/DollarSkip/archive/refs/heads/master.zip) or you can download the most stable version [here](https://github.com/CleanMachine1/DollarSkip/archive/refs/tags/1.0.zip) and compile `dollarskip.c` with `gcc dollarskip.c -o temp` then move `temp` to `/usr/bin/$` with `sudo mv temp /usr/bin/\$`.
+If you don't want to use Git and Make, you can download the zip from [here](https://github.com/CleanMachine1/DollarSkip/archive/refs/heads/master.zip) or you can download the most stable version [here](https://github.com/CleanMachine1/DollarSkip/archive/refs/tags/3.1.zip) and compile `dollarskip.c` with `gcc dollarskip.c -o temp` then move `temp` to `/usr/local/bin/$` with `sudo mv temp /usr/local/bin/\$`.
 
 </details>
 
@@ -52,7 +52,7 @@ cd ~/ # Or your place of choice for Git repositories
 git clone https://github.com/CleanMachine1/DollarSkip # Or use SSH
 cd DollarSkip 
 make # This makes the binary
-sudo make install # This copies the binary to /usr/bin and names it '$'
+sudo make install # This copies the binary to /usr/local/bin and names it '$'
 make clean # Removes the binary created above since it has already been moved
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ sudo rm /usr/local/bin/\$ # or /usr/bin/\$ (depending on when you installed).
 
 ## How this works
 
-DollarSkip makes a binary file called $, in return whenever the first word of a command is $ on its own, Linux see this as a application, since when installing, the $ file is moved to /usr/bin
+DollarSkip makes a binary file called $, in return whenever the first word of a command is $ on its own, Linux see this as a application, since when installing, the $ file is moved to /usr/local/bin/
 
 It can have side effects and if any occur, just run the uninstallation and tell me what went wrong!
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
-CC?=gcc
+CC ?= gcc
+PREFIX ?= /usr/local
 
 all: temp
 
@@ -6,10 +7,10 @@ temp: dollarskip.c
 	$(CC) dollarskip.c -o temp
 
 install: temp
-	cp temp /usr/bin/\$
+	cp temp $(PREFIX)/bin/\$
 
 uninstall:
-	-rm /usr/bin/\$
+	-rm $(PREFIX)/bin/\$
 
 clean:
 	-rm temp


### PR DESCRIPTION
There are many reasons to use this, like package managers, when building, don't want to install into the system.

It is [convention](https://refspecs.linuxbase.org/FHS_3.0/fhs-3.0.html#usrlocalLocalHierarchy) to not install directly into `/usr/bin`.