### PR TITLE
PKGBUILD: Also use `make` for installing

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,8 +14,8 @@ build() {
 }
 
 package() {
-    cd DollarSkip-${pkgver} &&
-    install -m 755 -D temp "${pkgdir}/usr/local/bin/\$" 
+    cd DollarSkip-${pkgver}
+    make install PREFIX="${pkgdir}/usr" 
 }
 
 sha256sums=('bd46bdc03aa1cdd4b8cd4814091fee35b8f1c176d395ccb1c6eadf805e76045a')


### PR DESCRIPTION
And I switched that one back to `/usr` instead of `/usr/local`, because the AUR is part of the distribution.