### PR TITLE
makefile: fix non-escaped dollar sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ all: dollarskip
 install: dollarskip
 	$(STRIP) dollarskip
 	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 dollarskip $(DESTDIR)$(PREFIX)/bin/\$
+	install -m 755 dollarskip $(DESTDIR)$(PREFIX)/bin/\$$
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/\$
+	rm -f $(DESTDIR)$(PREFIX)/bin/\$$
 
 clean:
 	rm -f dollarskip

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ all: dollarskip
 
 install: dollarskip
 	$(STRIP) dollarskip
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 755 dollarskip $(DESTDIR)$(PREFIX)/bin/\$$
+	install -d '$(DESTDIR)$(PREFIX)/bin'
+	install -m 755 dollarskip '$(DESTDIR)$(PREFIX)/bin/$$'
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/bin/\$$
+	rm -f '$(DESTDIR)$(PREFIX)/bin/$$'
 
 clean:
 	rm -f dollarskip


### PR DESCRIPTION
have you ever tested `make install` or `make uninstall`? it just runs something like `cp temp /tmp/foo/usr/bin/\` without the dollar sign at the end, because make likes to eat them for lunch.