### PR TITLE
Fix Workflow 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           name: DollarSkip_build
-          path: ./temp
+          path: ./dollarskip


### PR DESCRIPTION
The workflow for building a debug binary has become broken due to the Makefile no longer using ./temp rather ./dollarskip

This fixes it.